### PR TITLE
chore: refine yamllint configuration

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -10,14 +10,15 @@ yaml-files:
   - '.yamllint'
 
 rules:
-  braces: enable
+  braces:
+    max-spaces-inside: 1
   brackets: enable
   colons: enable
   commas: enable
   comments:
     level: error
-  comments-indentation:
-    level: error
+    min-spaces-from-content: 1
+  comments-indentation: false
   document-end: disable
   document-start:
     level: error
@@ -30,7 +31,9 @@ rules:
   line-length: disable
   new-line-at-end-of-file: enable
   new-lines: enable
-  octal-values: disable
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
   quoted-strings: disable
   trailing-spaces: enable
   truthy: disable


### PR DESCRIPTION
## Summary
- enforce comment spacing and consistent braces handling in yamllint
- tighten octal value checks and disable comments-indentation rule

## Testing
- `ansible-lint` *(fails: role 'mamono210.epel' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689097284c308326972a16da604b0be2