### PR TITLE
docs: add testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Example Playbook
     - cowsay
 ```
 
+Testing
+-------
+
+The role includes a Molecule scenario and linting configuration. You can
+run the checks locally with:
+
+```bash
+yamllint .
+ansible-lint
+molecule test
+```
+
 License
 -------
 


### PR DESCRIPTION
## Summary
- document how to run lint and Molecule tests

## Testing
- `yamllint .`
- `ansible-lint` *(fails: the role `mamono210.epel` was not found)*
- `molecule test` *(fails: could not install required collection `community.docker`)*

------
https://chatgpt.com/codex/tasks/task_e_6890a30af2e88326bd93994463874946